### PR TITLE
undisturbState update after lanuch app

### DIFF
--- a/EaseIM/EaseIM/Class/AppDelegate.m
+++ b/EaseIM/EaseIM/Class/AppDelegate.m
@@ -217,6 +217,10 @@
         }
         
         [[EMClient sharedClient].pushManager getPushNotificationOptionsFromServerWithCompletion:^(EMPushOptions * _Nonnull aOptions, EMError * _Nonnull aError) {
+            if (!aError) {
+                [[EaseIMKitManager shared] cleanMemoryUndisturbMaps];
+                [[NSNotificationCenter defaultCenter] postNotificationName:@"EMUserPushConfigsUpdateSuccess" object:nil];//更新用户重启App时，会话免打扰状态UI同步
+            }
         }];
         [[EMClient sharedClient].groupManager getJoinedGroupsFromServerWithPage:0 pageSize:-1 completion:^(NSArray *aList, EMError *aError) {
             if (!aError) {


### PR DESCRIPTION
App杀死重新启动后获取pushconfig的时候，UI提前刷新导致会话列表的免打扰状态不正确，需要在appdelegate中获取pushconfig成功后发送通知，在conversations列表中刷新list